### PR TITLE
adds scrolling arrows to image gallery when there are more than seven…

### DIFF
--- a/react-client/dist/overviewStyles.css
+++ b/react-client/dist/overviewStyles.css
@@ -10,19 +10,24 @@ button:focus {
   outline: none;
 }
 
+button:hover {
+  cursor: pointer;
+}
+
 .overview {
   width: 100%;
   display: flex;
   flex-flow: row wrap;
   border-bottom: 1px solid black;
-  padding: 1%;
+  padding: 0.1%;
 }
 
 .image-gallery-outer {
   display: flex;
   flex-flow: column;
   justify-content: flex-start;
-  width: 60%;
+  width: 70%;
+  height: 500px;
 }
 
 .image-gallery {
@@ -30,40 +35,68 @@ button:focus {
   flex-direction: row nowrap;
 }
 
+.arrow-container {
+  height: 20px;
+  width: 40px;
+}
+
 .arrow-button {
+  justify-content: center;
   text-align: center;
+  background: none;
+  border: none;
+  font-size: 20px;
+  color: lightgrey;
+  height: 20px;
+  width: 40px;
+  z-index: 2;
 }
 
 img.main-img {
-  max-width: 512px;
-  max-height: 360px;
+  position: absolute;
+  max-width: 600px;
+  max-height: 600px;
 }
 
-.image-thumbnail {
-  height: 50px;
-  width: 50px;
-  margin: 3px;
-  border: 2px solid black;
+#left {
+  position: absolute;
+  top: 10px;
+  left: 50px;
 }
 
-/* .image-thumbnail-hidden {
-
-} */
-
-
-.image-thumbnail#selected {
-  border: 2px solid rgb(255, 0, 140);
+#right {
+  position: absolute;
+  top: 10px;
+  left: 100px;
 }
 
 .gallery-thumbnails {
   display: flex;
   flex-flow: column nowrap;
-  z-index: 10;
+  z-index: 1;
+  position: absolute;
+}
+
+.image-thumbnail {
+  height: 40px;
+  width: 40px;
+  margin: 2px;
+  border: 2px solid black;
+}
+
+.image-thumbnail-hidden {
+  width: 0;
+  height: 0;
+  opacity: 0;
+}
+
+.image-thumbnail#selected {
+  border: 2px solid rgb(255, 0, 140);
 }
 
 .right-side {
   display: flex;
-  width: 40%;
+  width: 30%;
   flex-direction: column;
   justify-content: right;
 }
@@ -86,10 +119,11 @@ img.main-img {
 
 .checkmark {
   position: relative;
-  margin-bottom: -15px;
+  margin-bottom: -1rem;
+  margin-left: 2rem;
   width: 18px;
   height: 18px;
-  font-size: 16px;
+  font-size: 15px;
   border-radius: 50%;
   text-align: center;
   background-color: white;
@@ -99,7 +133,7 @@ img.main-img {
 
 .checkmark#on {
   opacity: 1;
-  z-index: 10;
+  z-index: 1;
 }
 
 .checkmark#off {
@@ -124,7 +158,7 @@ img.main-img {
   background-color: white;
   width: 220px;
   height: 40px;
-  font-size: 16px;
+  font-size: 18px;
   padding: 2%;
   margin-right: 10px;
   transition-duration: 0.25s;
@@ -153,7 +187,7 @@ select:hover {
 }
 
 select#size-selector {
-  font-size: 16px;
+  font-size: 18px;
   width: 180px;
   height: 40px;
   padding: 1%;
@@ -162,7 +196,7 @@ select#size-selector {
 }
 
 select#qty-selector {
-  font-size: 16px;
+  font-size: 18px;
   width: 80px;
   height: 40px;
   padding: 1%;
@@ -174,7 +208,6 @@ select#qty-selector {
   flex-direction: column;
   justify-content: flex-start;
   padding-left: 1%;
-  padding-top: 1%;
 }
 
 .product-slogan {

--- a/react-client/src/components/product-overview/ImageGallery.jsx
+++ b/react-client/src/components/product-overview/ImageGallery.jsx
@@ -1,23 +1,39 @@
 import React, { useState, useEffect } from 'react';
-// import axios from 'axios';
-// import header from '../../../../config.js';
 
-export default function ImageGallery(props) {
-
-  const { selectPhoto, photos } = props;
+export default function ImageGallery({ selectPhoto, photos }) {
 
   // By default, the first image in the set will be displayed as the main image
   // When switching between styles, the index of the image currently selected should be maintained when the gallery updates for the new style
 
   const [selectedPhotoIndex, changePhotoIndex] = useState(0);
-  const [expandedGalleryView, toggleGalleryView] = useState(false); // Conditional render image gallery based on this
+  // note - some larger imgs currently bleed out of overview component, need to somehow standardize the image sizes and/or the size of the gallery component itself
 
-  // The largest piece of the Overview module will be a photo gallery showing images of the product.  The photos presented in this gallery will be specific to the currently selected product style.  Each time a new style is chosen, the gallery will update to show photos corresponding to the new style.   Each style will have a set of images associated with it.  The gallery will allow customers to browse between and zoom in on these photos.
   // The gallery will be viewable in two states.  A default collapsed view, and an expanded view.
+  const [expandedGalleryView, toggleGalleryView] = useState(false);
 
-  // const between = (target, min, max) => {
-  //   return target >= min && target <= max;
-  // }
+  // useEffect(() => {
+  //   console.log(selectedPhotoIndex)
+  // }, [selectedPhotoIndex])
+
+
+  const between = (target, min, max) => {
+    return target >= min && target <= max;
+  }
+
+  // this shows the correct number of thumbnails but is still a bit buggy with what thumbnails display, even though you can scroll through them fine with the arrows. i think the logic in the else block is off
+  const shouldShowThumbnail = (idx) => {
+    if (selectedPhotoIndex + 6 < photos.length) {
+      return between(idx, selectedPhotoIndex, selectedPhotoIndex + 6)
+    } else {
+      let diff = Math.abs((selectedPhotoIndex + 6) - photos.length)
+      if (between(idx, 0, diff)) {
+        return true;
+      } else {
+        return between(idx, selectedPhotoIndex, photos.length)
+      }
+    }
+  }
+
 
   const renderThumbnails = () => {
     if (photos.length < 7) {
@@ -38,24 +54,25 @@ export default function ImageGallery(props) {
       </div>
     } else {
       return <div className='gallery-thumbnails-container'>
-        <button className='arrow-button' onClick={() => scrollBack()}>↑</button>
-
-        {/* Up to 7  thumbnail images will be displayed at a given time in the list. this isnt implemented  yet*/}
+        {/* Up to 7  thumbnail images will be displayed at a given time in the list. this is implemented, but some thumbnails have the wrong image even though scrolling through them works properly. todo */}
         <div className='gallery-thumbnails'>
+          <div className='arrow-container'>
+            {selectedPhotoIndex > 0 ? <button className='arrow-button' onClick={() => scrollBack()}>&#8963;</button> : null}
+          </div>
           {photos.map((photo, i) => {
             return <img
-              className='image-thumbnail'
+              className={shouldShowThumbnail(i) ? 'image-thumbnail' : 'image-thumbnail-hidden'}
               key={i}
               src={photo.thumbnail_url}
-              // Clicking on any thumbnail should update the main image to match that shown in the thumbnail clicked
               onClick={() => handleSelect(photo.url, i)}
-              // The thumbnail corresponding to the image currently selected as the main image should be highlighted to indicate the current selection.
               id={i === selectedPhotoIndex ? 'selected' : null}
             />
           })}
+          <div className='arrow-container'>
+            {selectedPhotoIndex < photos.length - 1 ? <button className='arrow-button' onClick={() => scrollForward()}>&#8964;</button> : null}
+          </div>
         </div>
 
-        <button className='arrow-button' onClick={() => scrollForward()}>↓</button>
       </div>
     }
   }
@@ -89,12 +106,16 @@ export default function ImageGallery(props) {
         <div className='image-gallery'>
           {renderThumbnails()}
           <img className='main-img' src={photos[selectedPhotoIndex].url}></img>
+          <div>
+          {selectedPhotoIndex > 0 ?
+            <button id='left' className='arrow-button' onClick={() => scrollBack()}>&#x2190;</button>
+            : null}
+          {selectedPhotoIndex < photos.length - 1 ?
+            <button id='right' className='arrow-button' onClick={() => scrollForward()}>&#x2192;</button>
+            : null}
+          </div>
         </div>
         : null}
-      <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center' }}>
-        {selectedPhotoIndex > 0 ? <button className='arrow-button' onClick={() => scrollBack()}>←</button> : null}
-        {selectedPhotoIndex < photos.length - 1 ? <button className='arrow-button' onClick={() => scrollForward()}>→</button> : null}
-      </div>
     </div>
   )
 };

--- a/react-client/src/components/product-overview/Overview.jsx
+++ b/react-client/src/components/product-overview/Overview.jsx
@@ -11,7 +11,8 @@ import StyleSelector from './StyleSelector.jsx';
 
 export default function Overview(props) {
 
-  // in App, use product page 1 and selectedItemIndex 2 to demo Overview component where there are actually many styles/images; a lot of them only have one image per style
+  // use product page 1 selectedItemIndex 9 (shoes) to demo image gallery arrows (which only appear when there's more than 7 thumbnails)
+
   const {products, selectedItemIndex, avgRating} = props;
 
   const [selectedStyle, selectStyle] = useState(0);
@@ -22,7 +23,7 @@ export default function Overview(props) {
 
   return (
     <div className='overview'>
-      <ImageGallery selectedPhoto={selectedPhoto} selectPhoto={selectPhoto} photos={photos} />
+      <ImageGallery selectedPhoto={selectedPhoto} selectPhoto={selectPhoto} photos={photos} selectedProduct={products[selectedItemIndex] || null} />
       <div className='right-side'>
         <ProductInformation selectedProduct={products[selectedItemIndex] || null} selectedStyle={selectedStyle} price={price} sale={sale} avgRating={avgRating} />
         <StyleSelector selectedProduct={products[selectedItemIndex] || null} selectedStyle={selectedStyle} selectStyle={selectStyle} updatePrice={updatePrice} updateSale={updateSale} selectPhoto={selectPhoto} updatePhotos={updatePhotos} />

--- a/react-client/src/components/product-overview/ProductDescription.jsx
+++ b/react-client/src/components/product-overview/ProductDescription.jsx
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 
-function ProductDescription(props) {
-
-  const { selectedProduct } = props;
+function ProductDescription({selectedProduct}) {
 
   // think i saw that some products have a 'features' property, those should go on here where the checkmarks are in mock (bottom-right)
 


### PR DESCRIPTION
… photos for the selected product+style. user can scroll through them fine but sometimes the thumbnails dont correspond to the img that they should, still need to fix. also  moved check mark on selected style to right side as shown in mock

(can use product page 1 item index 9 , hare force one shoes, to test the arrows if you want)