### PR TITLE
started expanded view functionality, minor tweaks elsewhere

### DIFF
--- a/react-client/dist/overviewStyles.css
+++ b/react-client/dist/overviewStyles.css
@@ -17,10 +17,43 @@
 }
 
 .image-gallery {
-  /* curret selected img gets passed as background of .image-gallery */
+  /* current selected img gets passed as background of .image-gallery */
   display: flex;
   flex-direction: row nowrap;
   cursor: zoom-in;  /* when clicked, should open an expanded view modal */
+}
+
+#expanded-gallery-view {
+  /* react-modal */
+  display: flex;
+  flex-direction: column;
+}
+
+/* #expanded-view-img {
+} */
+
+/* Instead of displaying a magnifying glass on hover, in the expanded view the mouse should become a “+” symbol while hovering over the main image. */
+#expanded-view-img:hover {
+  cursor: crosshair
+}
+
+.expanded-view-icons-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.expanded-view-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid black;
+  margin: 0.1rem;
+  background: none;
+  transition-duration: 0.25s;
+}
+
+.expanded-view-icon#selected {
+  background: rgb(255, 0, 140);
 }
 
 .arrow-button {
@@ -115,6 +148,7 @@
 }
 
 .image-thumbnail {
+  z-index: 5;
   height: 40px;
   width: 40px;
   margin: 2px;
@@ -305,24 +339,24 @@
   background-color: lightgreen;
 }
 
-.selector {
+.dropdown {
   padding: 0.1%;
   height: 40px;
   font-size: 18px;
 }
 
-.selector:hover {
+.dropdown:hover {
   /* cursor change on hover not working for some reason */
   cursor: pointer;
 }
 
-.selector#size {
+.dropdown#size {
   width: 180px;
   margin-right: 10px;
   margin-bottom: 10px
 }
 
-.selector#qty {
+.dropdown#qty {
   width: 80px;
 }
 

--- a/react-client/dist/shared.css
+++ b/react-client/dist/shared.css
@@ -11,3 +11,8 @@ button:focus {
 button:hover {
   cursor: pointer;
 }
+
+/* makes all react-modals cover overview checkmarks + arrows */
+.ReactModal__Overlay {
+  z-index: 20;
+}

--- a/react-client/src/components/product-overview/AddToCart.jsx
+++ b/react-client/src/components/product-overview/AddToCart.jsx
@@ -134,7 +134,7 @@ export default function AddToCart({ selectedProduct, selectedStyle, styles, getS
           <div className='selector-container'>
           <Select
               id='qty'
-              className='selector'
+              className='dropdown'
               onFocus={() => toggleQtyMenu(true)}
               blurInputOnSelect={true}
               onChange={handleQtySelect}
@@ -146,7 +146,7 @@ export default function AddToCart({ selectedProduct, selectedStyle, styles, getS
             {/* size dropdown should become inactive and read OUT OF STOCK when there's no stock */}
             <Select
               id='size'
-              className='selector'
+              className='dropdown'
               onFocus={() => toggleSizeMenu(true)}
               blurInputOnSelect={true}
               onChange={handleSizeSelect}

--- a/react-client/src/components/product-overview/Overview.jsx
+++ b/react-client/src/components/product-overview/Overview.jsx
@@ -7,11 +7,9 @@ import AddToCart from './AddToCart.jsx';
 import ImageGallery from './ImageGallery.jsx';
 import StyleSelector from './StyleSelector.jsx';
 
-
-
 export default function Overview({products, selectedItemIndex, avgRating}) {
 
-  // use product page 1 selectedItemIndex 9 (shoes) to demo image gallery arrows (which only appear when there's more than 7 thumbnails)
+  // use product page 1 selectedItemIndex 9 (shoes) or product id 16060 to demo image gallery arrows (which only appear when there's more than 7 thumbnails)
 
   const [selectedStyle, selectStyle] = useState(0);
   const [price, updatePrice] = useState(0);

--- a/react-client/src/components/product-overview/ProductDescription.jsx
+++ b/react-client/src/components/product-overview/ProductDescription.jsx
@@ -23,16 +23,25 @@ function ProductDescription({ selectedProduct }) {
   }, [selectedProduct])
 
   const renderFeatures = () => {
-    // sometimes there are duplicate features on one product, should add logic to remove them before mapping
-    return features.map((feature, i) => {
+    // sometimes there are duplicate features on one product (???)
+    let uniqueFeatures = [];
+    for (let feature of features) {
+      if (!uniqueFeatures.includes(feature)) {
+        uniqueFeatures.push(feature)
+      }
+    }
+    return uniqueFeatures.map((feature, i) => {
+      let valueWithoutQuotes = '';
+      if (feature.value) {
+        valueWithoutQuotes = feature.value.replace(/^"|"$/g, ''); // remove quotation marks from values (not all features have a value prop)
+      }
       return <li key={i}>
-        <span>✔</span>
-        <span>{` ${feature.feature} `}</span>
-        <span>{feature.value}</span>
+        <span>✔ </span>
+        <span >{` ${feature.feature} `}</span>
+        <span style={{fontStyle: 'italic'}}>{valueWithoutQuotes}</span>
       </li>
     })
   }
-
 
   return (
     <div>
@@ -52,7 +61,6 @@ function ProductDescription({ selectedProduct }) {
         : null}
     </div >
   )
-
 };
 
 export default ProductDescription;


### PR DESCRIPTION
- started expanded view using react-modal
- added react-modal overlay z-index to shared css so that everyones modals will cover my checkmarks and arrows
- made row of circular icons that function the same as thumbnails in default view, for the expanded view. can scroll through expanded view gallery with either the left/right arrows or icon clicks, same as default view
- added logic to remove duplicate features from product description (why are there even duplicate features...?)
- minor css changes (rename .selector to .dropdown to not clash with michaels selector)
- expanded view still needs zoom in functionality, and should open and close onClick of the image itself rather than using buttons