### PR TITLE
Zoom in functionality

### DIFF
--- a/react-client/dist/overviewStyles.css
+++ b/react-client/dist/overviewStyles.css
@@ -416,23 +416,22 @@
   width: 100%;
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
-  padding: 0.1%;
-  border-bottom: 1px solid gray;
+  justify-content: space-between;
 }
 
 .slogan-description-container {
   display: flex;
   flex-direction: column;
-  width: 70%;
-  padding: 0.1%;
-  margin-right: 1%;
+  width: 74.4%; /* somehow this lines up with image gallery, maybe only on my screen... */
+  margin-top: 0.25%;
+  padding-left: 0.5%;
+  border-right: 2px solid gray;
 }
 
 .feature-list {
   display: flex;
   flex-direction: column;
-  width: 25%;
+  width: 20%;
   padding: 0.1%;
   font-size: 18px;
 }

--- a/react-client/dist/overviewStyles.css
+++ b/react-client/dist/overviewStyles.css
@@ -21,68 +21,7 @@
   display: flex;
   flex-direction: row nowrap;
   z-index: 5;
-  cursor: zoom-in;  /* when clicked, should open an expanded view modal */
-}
-
-#expanded-gallery-modal {
-  display: flex;
-  flex-direction: column;
-}
-
-/* .expanded-gallery-modal-inner {
-
-} */
-
-#modal-x-button {
-  width: 40px;
-  height: 40px;
-  font-size: 1.5rem;
-  color: gray;
-  border: none;
-  background: none;
-  transition-duration: 0.25s;
-}
-
-#modal-x-button:hover {
-  color: red
-}
-
-.expanded-arrow-and-icon-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-}
-
-/* Instead of displaying a magnifying glass on hover, in the expanded view the mouse should become a “+” symbol while hovering over the main image. */
-.expanded-view-image#not-zoomed:hover {
-  cursor: crosshair
-}
-
-.expanded-view-image#zoomed:hover {
-  cursor: all-scroll
-}
-
-.expanded-view-icons-row {
-  display: flex;
-  flex-direction: row;
-}
-
-.expanded-view-icon {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 2px solid black;
-  margin: 0.1rem;
-  background: none;
-  transition-duration: 0.25s;
-}
-
-.expanded-view-icon:hover {
-  cursor: pointer;
-}
-
-.expanded-view-icon#selected {
-  background: rgb(255, 0, 140);
+  cursor: zoom-in;
 }
 
 .arrow-button {
@@ -122,7 +61,7 @@
 .horizontal-arrow {
   background: none;
   border: none;
-  font-size: 30px;
+  font-size: 40px;
   color: gray;
   z-index: 2;
   position: relative;
@@ -144,11 +83,6 @@
   opacity: 1;
 }
 
-#right-arrow {
-  left: 82%;
-  opacity: 1;
-}
-
 #left-hidden {
   left: 3%;
   opacity: 0;
@@ -159,8 +93,13 @@
 }
 
 #right-hidden {
-  left: 82%;
+  left: 85%;
   opacity: 0;
+}
+
+#right-arrow {
+  left: 85%;
+  opacity: 1;
 }
 
 #right-hidden:hover {
@@ -184,8 +123,8 @@
   height: 40px;
   width: 40px;
   margin: 2px;
-  border: 2px solid gray;
-  border-radius: 0.25rem;
+  border: 2px solid black;
+  border-radius: 0.1rem;
   -webkit-user-select: none; /* Safari */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+/Edge */
@@ -194,6 +133,7 @@
 
 .image-thumbnail:hover {
   cursor: pointer;
+  border: 2px solid gray;
 }
 
 .image-thumbnail-hidden {
@@ -206,6 +146,76 @@
   border: 2px solid rgb(255, 0, 140);
 }
 
+/* ExpandedView.jsx */
+
+#expanded-gallery-modal {
+  display: flex;
+  flex-direction: column;
+}
+
+#modal-x-button {
+  width: 40px;
+  height: 40px;
+  font-size: 1.5rem;
+  color: gray;
+  border: none;
+  background: none;
+  transition-duration: 0.25s;
+}
+
+#modal-x-button:hover {
+  color: red
+}
+
+.expanded-arrow-and-icon-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+.expanded-gallery-modal-inner {
+  justify-content: center;
+}
+
+.expanded-view-image {
+  display: block;
+  margin: auto;
+}
+
+/* Instead of displaying a magnifying glass on hover, in the expanded view the mouse should become a “+” symbol while hovering over the main image. */
+.expanded-view-image#not-zoomed:hover {
+  cursor: crosshair
+}
+
+/* while zoomed in and panning around display four-way cursor */
+.expanded-view-image#zoomed:hover {
+  cursor: all-scroll
+}
+
+.expanded-view-icons-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.expanded-view-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid black;
+  margin: 0.1rem;
+  background: none;
+  transition-duration: 0.25s;
+}
+
+.expanded-view-icon:hover {
+  cursor: pointer;
+}
+
+.expanded-view-icon#selected {
+  background: rgb(255, 0, 140);
+}
+
+/* wrapper for everything besides gallery and description*/
 .right-side {
   display: flex;
   width: 20%;
@@ -414,7 +424,7 @@
 .slogan-description-container {
   display: flex;
   flex-direction: column;
-  width: 75%;
+  width: 70%;
   padding: 0.1%;
   margin-right: 1%;
 }
@@ -422,7 +432,7 @@
 .feature-list {
   display: flex;
   flex-direction: column;
-  width: 20%;
+  width: 25%;
   padding: 0.1%;
   font-size: 18px;
 }

--- a/react-client/dist/overviewStyles.css
+++ b/react-client/dist/overviewStyles.css
@@ -23,17 +23,19 @@
   cursor: zoom-in;  /* when clicked, should open an expanded view modal */
 }
 
-#expanded-gallery-view {
-  /* react-modal */
+#expanded-gallery-modal {
   display: flex;
   flex-direction: column;
 }
 
-/* #expanded-view-img {
-} */
+.expanded-arrow-and-icon-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
 
 /* Instead of displaying a magnifying glass on hover, in the expanded view the mouse should become a “+” symbol while hovering over the main image. */
-#expanded-view-img:hover {
+.expanded-view-image:hover {
   cursor: crosshair
 }
 

--- a/react-client/dist/overviewStyles.css
+++ b/react-client/dist/overviewStyles.css
@@ -20,12 +20,31 @@
   /* current selected img gets passed as background of .image-gallery */
   display: flex;
   flex-direction: row nowrap;
+  z-index: 5;
   cursor: zoom-in;  /* when clicked, should open an expanded view modal */
 }
 
 #expanded-gallery-modal {
   display: flex;
   flex-direction: column;
+}
+
+/* .expanded-gallery-modal-inner {
+
+} */
+
+#modal-x-button {
+  width: 40px;
+  height: 40px;
+  font-size: 1.5rem;
+  color: gray;
+  border: none;
+  background: none;
+  transition-duration: 0.25s;
+}
+
+#modal-x-button:hover {
+  color: red
 }
 
 .expanded-arrow-and-icon-container {
@@ -35,8 +54,12 @@
 }
 
 /* Instead of displaying a magnifying glass on hover, in the expanded view the mouse should become a “+” symbol while hovering over the main image. */
-.expanded-view-image:hover {
+.expanded-view-image#not-zoomed:hover {
   cursor: crosshair
+}
+
+.expanded-view-image#zoomed:hover {
+  cursor: all-scroll
 }
 
 .expanded-view-icons-row {
@@ -144,10 +167,13 @@
   cursor: auto;
 }
 
+.gallery-thumbnails-container {
+  z-index: 10;
+}
+
 .gallery-thumbnails {
   display: flex;
   flex-flow: column nowrap;
-  z-index: 1;
   position: relative;
   top: 10px;
   left: 10px;
@@ -164,6 +190,10 @@
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+/Edge */
   user-select: none; /* Standard */
+}
+
+.image-thumbnail:hover {
+  cursor: pointer;
 }
 
 .image-thumbnail-hidden {

--- a/react-client/src/components/App.jsx
+++ b/react-client/src/components/App.jsx
@@ -89,20 +89,20 @@ export default class App extends React.Component {
         <Overview
           product={this.state.selectedProduct}
           avgRating={this.state.avgRating} />
-        {/* <RelatedItemsList
+         {/* <RelatedItemsList
           selectProduct={this.selectProduct}
           avgRating={this.state.avgRating}
-          currentProduct={this.state.selectedProduct} /> */}
-        {/* <YourOutfitList
-          avgRating={this.state.avgRating}
           currentProduct={this.state.selectedProduct} />
-        {/* <QA
+        <YourOutfitList
+          avgRating={this.state.avgRating}
           currentProduct={this.state.selectedProduct} /> */}
+        {/*<QA
+          currentProduct={this.state.selectedProduct} />
         <Reviews
           avgRating={this.state.avgRating}
           metadata={this.state.metadata}
           getRatings={this.getRatings}
-          currentProduct={this.state.selectedProduct.id} />
+          currentProduct={this.state.selectedProduct.id} /> */}
       </div>
     )
   }

--- a/react-client/src/components/App.jsx
+++ b/react-client/src/components/App.jsx
@@ -43,17 +43,17 @@ export default class App extends React.Component {
     let rounded = Math.round(averageScore * 4) / 4;
     this.setState({
       avgRating: rounded
-  })
-}
+    })
+  }
 
   selectProduct(id) {
     axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-lax/products/${id}`, header)
-    .then((results) => {
-      this.setState({
-        selectedProduct: results.data
+      .then((results) => {
+        this.setState({
+          selectedProduct: results.data
+        })
       })
-    })
-    .catch(err => (console.log(err)))
+      .catch(err => (console.log(err)))
   }
 
   getProducts() {
@@ -89,20 +89,20 @@ export default class App extends React.Component {
         <Overview
           product={this.state.selectedProduct}
           avgRating={this.state.avgRating} />
-         {/* <RelatedItemsList
+        <RelatedItemsList
           selectProduct={this.selectProduct}
           avgRating={this.state.avgRating}
           currentProduct={this.state.selectedProduct} />
         <YourOutfitList
           avgRating={this.state.avgRating}
-          currentProduct={this.state.selectedProduct} /> */}
-        {/*<QA
+          currentProduct={this.state.selectedProduct} />
+        <QA
           currentProduct={this.state.selectedProduct} />
         <Reviews
           avgRating={this.state.avgRating}
           metadata={this.state.metadata}
           getRatings={this.getRatings}
-          currentProduct={this.state.selectedProduct.id} /> */}
+          currentProduct={this.state.selectedProduct.id} />
       </div>
     )
   }

--- a/react-client/src/components/product-overview/ExpandedView.jsx
+++ b/react-client/src/components/product-overview/ExpandedView.jsx
@@ -1,39 +1,19 @@
 import React, { useState, useEffect, createRef } from 'react';
+import PrismaZoom from 'react-prismazoom'
 
-// import PrismaZoom from 'react-prismazoom'
-// <PrismaZoom>
-//   <img src="my-image.png" />
-//   <p>A text that can be zoomed and dragged</p>
-// </PrismaZoom>
+export default function ExpandedView({ close, handleIconClick, url, photos, back, forward, selectedPhotoIndex }) {
 
-export default function ExpandedView({close, handleIconClick, url, photos, back, forward, selectedPhotoIndex}) {
+  const prismaZoom = createRef();
 
-  const [currentHeight, setHeight] = useState(null);
-  const [currentWidth, setWidth] = useState(null);
-
-  const imgRef = createRef();
-  let initialHeight;
-  let initialWidth;
-
-  useEffect(() => {
-    // save initial image dimensions
-    initialHeight = imgRef.current.clientHeight;
-    initialWidth = imgRef.current.clientWidth;
-  }, []);
-
-  const handleZoomIn = () => {
-    let height = imgRef.current.clientHeight
-    let width = imgRef.current.clientWidth
-    setHeight(currentHeight * 2.5);
-    setWidth(currentWidth * 2.5);
+  const onClickOnZoomOut = () => {
+    prismaZoom.current.zoomOut(1)
   }
 
-  const handleZoomOut = () => {
-    setHeight(initialHeight);
-    setWidth(initialWidth);
+  const onClickOnZoomIn = () => {
+    prismaZoom.current.zoomIn(2.5)
   }
 
-  const renderExpandedViewIcons = () =>  {
+  const renderExpandedViewIcons = () => {
     return <div className='expanded-view-icons-row'>
       {photos.map((photo, i) => {
         return <div
@@ -41,8 +21,8 @@ export default function ExpandedView({close, handleIconClick, url, photos, back,
           key={i}
           onClick={() => handleIconClick(photo.url, i)}
           id={i === selectedPhotoIndex ? 'selected' : null}
-          >
-          </div>
+        >
+        </div>
       })}
     </div>
   }
@@ -50,20 +30,19 @@ export default function ExpandedView({close, handleIconClick, url, photos, back,
   return (
     <div>
       <div>
-        <button onClick={() => close()} style={{ width: 60, height: 20 }}>CLOSE</button>
-        <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'center' }}>
-          <button onClick={() => handleZoomIn}>Zoom In</button>
-          <button onClick={() => handleZoomOut}>Zoom Out</button>
-          <button onClick={back()}>&#x2190;</button>
-          <div>{renderExpandedViewIcons()}</div>
-          <button onClick={forward()}>&#x2192;</button>
+        <button onClick={() => close()} style={{ width: 20, height: 20 }}>X</button>
+        <div className='expanded-arrow-and-icon-container'>
+          <button className='expanded-arrow-button' onClick={back()}>&#x2190;</button>
+          {renderExpandedViewIcons()}
+          <button className='expanded-arrow-button' onClick={forward()}>&#x2192;</button>
         </div>
-        {/* Assign reference to DOM element     */}
-        <img id='expanded-image' style={{width: currentWidth, height: currentHeight}} ref={imgRef} src={url} alt='hello world' />
+        <PrismaZoom
+          maxZoom={2.5}
+          ref={prismaZoom}
+        >
+          <img className='expanded-view-image' src={url} />
+        </PrismaZoom>
       </div>
-
     </div>
-
   )
-
 }

--- a/react-client/src/components/product-overview/ExpandedView.jsx
+++ b/react-client/src/components/product-overview/ExpandedView.jsx
@@ -3,6 +3,8 @@ import PrismaZoom from 'react-prismazoom'
 
 export default function ExpandedView({ close, handleIconClick, url, photos, back, forward, selectedPhotoIndex }) {
 
+  const [isZoomed, toggleZoom] = useState(false);
+
   const prismaZoom = createRef();
 
   const onClickOnZoomOut = () => {
@@ -19,7 +21,7 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
         return <div
           className='expanded-view-icon'
           key={i}
-          onClick={() => handleIconClick(photo.url, i)}
+          onClick={(e) => handleIconClick(e, photo.url, i)}
           id={i === selectedPhotoIndex ? 'selected' : null}
         >
         </div>
@@ -28,21 +30,20 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
   }
 
   return (
-    <div>
-      <div>
-        <button onClick={() => close()} style={{ width: 20, height: 20 }}>X</button>
-        <div className='expanded-arrow-and-icon-container'>
-          <button className='expanded-arrow-button' onClick={back()}>&#x2190;</button>
-          {renderExpandedViewIcons()}
-          <button className='expanded-arrow-button' onClick={forward()}>&#x2192;</button>
-        </div>
-        <PrismaZoom
-          maxZoom={2.5}
-          ref={prismaZoom}
-        >
-          <img className='expanded-view-image' src={url} />
-        </PrismaZoom>
+    <div className='expanded-gallery-modal-inner'>      <button onClick={() => close()} id='modal-x-button'>&#x2715;</button>
+      <div className='expanded-arrow-and-icon-container'>
+        <div className='arrow-container'>{selectedPhotoIndex > 0 ? <button className='arrow-button' onClick={(e) => {back(e)}}>&#x2190;</button> : null}</div>
+        {renderExpandedViewIcons()}
+        <div className='arrow-container'>{selectedPhotoIndex < photos.length - 1? <button className='arrow-button' onClick={(e) => {forward(e)}}>&#x2192;</button> : null}</div>
       </div>
+      <PrismaZoom
+        onZoomChange={() => toggleZoom(!isZoomed)}
+        minZoom={1}
+        maxZoom={2.5}
+        ref={prismaZoom}
+      >
+        <img className='expanded-view-image' id={isZoomed ? 'zoomed' : 'not-zoomed'} src={url} />
+      </PrismaZoom>
     </div>
   )
 }

--- a/react-client/src/components/product-overview/ExpandedView.jsx
+++ b/react-client/src/components/product-overview/ExpandedView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createRef } from 'react';
+import React, { useState, createRef } from 'react';
 import PrismaZoom from 'react-prismazoom'
 
 export default function ExpandedView({ close, handleIconClick, url, photos, back, forward, selectedPhotoIndex }) {
@@ -6,14 +6,6 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
   const [isZoomed, toggleZoom] = useState(false);
 
   const prismaZoom = createRef();
-
-  const onClickOnZoomOut = () => {
-    prismaZoom.current.zoomOut(1)
-  }
-
-  const onClickOnZoomIn = () => {
-    prismaZoom.current.zoomIn(2.5)
-  }
 
   const renderExpandedViewIcons = () => {
     return <div className='expanded-view-icons-row'>
@@ -30,18 +22,23 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
   }
 
   return (
-    <div className='expanded-gallery-modal-inner'>      <button onClick={() => close()} id='modal-x-button'>&#x2715;</button>
+    <div className='expanded-gallery-modal-inner'>
+      <button onClick={() => close()} id='modal-x-button'>&#x2715;</button>
       <div className='expanded-arrow-and-icon-container'>
-        <div className='arrow-container'>{selectedPhotoIndex > 0 ? <button className='arrow-button' onClick={(e) => {back(e)}}>&#x2190;</button> : null}</div>
+        <div className='arrow-container'>
+          {selectedPhotoIndex > 0 ? <button className='arrow-button' onClick={(e) => {back(e)}}>&#x2190;</button> : null}
+        </div>
         {renderExpandedViewIcons()}
-        <div className='arrow-container'>{selectedPhotoIndex < photos.length - 1? <button className='arrow-button' onClick={(e) => {forward(e)}}>&#x2192;</button> : null}</div>
+        <div className='arrow-container'>
+          {selectedPhotoIndex < photos.length - 1? <button className='arrow-button' onClick={(e) => {forward(e)}}>&#x2192;</button> : null}
+        </div>
       </div>
       <PrismaZoom
         onZoomChange={() => toggleZoom(!isZoomed)}
         minZoom={1}
         maxZoom={2.5}
         ref={prismaZoom}
-      >
+        >
         <img className='expanded-view-image' id={isZoomed ? 'zoomed' : 'not-zoomed'} src={url} />
       </PrismaZoom>
     </div>

--- a/react-client/src/components/product-overview/ImageGallery.jsx
+++ b/react-client/src/components/product-overview/ImageGallery.jsx
@@ -155,12 +155,12 @@ export default function ImageGallery({ selectPhoto, photos }) {
           style={mainImageCSS(photos[selectedPhotoIndex].url)}
           >
           {/* EXPANDED VIEW */}
-          <Modal id='expanded-gallery-view' isOpen={expandedGalleryView} style={modalStyle} ariaHideApp={false} >
+          <Modal id='expanded-gallery-modal' isOpen={expandedGalleryView} style={modalStyle} ariaHideApp={false} >
             <ExpandedView
               close={() => toggleGalleryView(false)}
               photos={photos}
-              url={photos[selectedPhotoIndex].url}
               selectedPhotoIndex={selectedPhotoIndex}
+              url={photos[selectedPhotoIndex].url}
               handleIconClick={handleIconClick}
               back={() => scrollBack}
               forward={() => scrollForward}

--- a/react-client/src/components/product-overview/ImageGallery.jsx
+++ b/react-client/src/components/product-overview/ImageGallery.jsx
@@ -3,12 +3,12 @@ import ExpandedView from './ExpandedView.jsx';
 import Modal from 'react-modal';
 
 const modalStyle = {
-  content : {
-    top                   : '0.5%',
-    left                  : 0,
-    right                 : 0,
-    overflowX             : 'hidden',
-    height                : 800,
+  content: {
+    top: 0,
+    left: 0,
+    right: 0,
+    overflowX: 'hidden',
+    height: 800,
   }
 };
 
@@ -52,7 +52,9 @@ export default function ImageGallery({ selectPhoto, photos }) {
               key={i}
               src={photo.thumbnail_url}
               // Clicking on any thumbnail should update the main image to match that shown in the thumbnail clicked
-              onClick={() => handleThumbnailClick(photo.url, i)}
+              onClick={(event) => {
+                handleThumbnailClick(event, photo.url, i)
+              }}
               // The thumbnail corresponding to the image currently selected as the main image should be highlighted to indicate the current selection.
               id={i === selectedPhotoIndex ? 'selected' : null}
             />
@@ -63,32 +65,36 @@ export default function ImageGallery({ selectPhoto, photos }) {
       return <div className='gallery-thumbnails-container'>
         <div className='gallery-thumbnails'>
           <div className='arrow-container'>
-            <button className={selectedPhotoIndex > 0 ? 'arrow-button' : 'arrow-button-hidden'} onClick={() => scrollBack()}>&#8963;</button>
+            <button className={selectedPhotoIndex > 0 ? 'arrow-button' : 'arrow-button-hidden'}  onClick={(event) => {scrollBack(event)}}>&#8963;</button>
           </div>
           {photos.map((photo, i) => {
             return <img
               className={shouldShowThumbnail(i) ? 'image-thumbnail' : 'image-thumbnail-hidden'}
               key={i}
               src={photo.thumbnail_url}
-              onClick={() => handleThumbnailClick(photo.url, i)}
+              onClick={(event) => {
+                handleThumbnailClick(event, photo.url, i)
+              }}
+              // onClick={() => handleThumbnailClick(photo.url, i)}
               id={i === selectedPhotoIndex ? 'selected' : null}
             />
           })}
           <div className='arrow-container' style={{ marginTop: -10 }}>
-            <button className={selectedPhotoIndex < photos.length - 1 ? 'arrow-button' : 'arrow-button-hidden'} onClick={() => scrollForward()}>&#8964;</button>
+            <button className={selectedPhotoIndex < photos.length - 1 ? 'arrow-button' : 'arrow-button-hidden'} onClick={(event) => {scrollForward(event)}}>&#8964;</button>
           </div>
         </div>
-
       </div>
     }
   }
 
-  const handleThumbnailClick = (url, idx) => {
+  const handleThumbnailClick = (event, url, idx) => {
+    event.stopPropagation();
     selectPhoto(url);
     changePhotoIndex(idx);
   }
 
-  const scrollForward = () => {
+  const scrollForward = (event) => {
+    event.stopPropagation();
     if (selectedPhotoIndex === photos.length - 1) {
       return
       // changePhotoIndex(0) for infinite scroll
@@ -98,7 +104,8 @@ export default function ImageGallery({ selectPhoto, photos }) {
     }
   }
 
-  const scrollBack = () => {
+  const scrollBack = (event) => {
+    event.stopPropagation();
     if (selectedPhotoIndex === 0) {
       return
       // changePhotoIndex(photos.length - 1) for infinite scroll
@@ -120,32 +127,6 @@ export default function ImageGallery({ selectPhoto, photos }) {
     }
   }
 
-  // In the expanded view, thumbnails will not appear over the main image.  Instead, icons indicating each image in the set will appear.  These icons will be much smaller, but will have the same functionality in that clicking on them will skip to that image in the set.   Additionally the icon for the currently selected image will be distinguishably different from the rest.
-
-  const renderExpandedViewIcons = () => {
-    return <div className='expanded-view-icons-row'>
-      {photos.map((photo, i) => {
-        return <div
-          className='expanded-view-icon'
-          key={i}
-          onClick={() => handleIconClick(photo.url, i)}
-          id={i === selectedPhotoIndex ? 'selected' : null}
-          >
-          </div>
-      })}
-    </div>
-  }
-
-  // this is exactly the same as handleThumbNailClick rn, not sure if they will end up needing slightly diff functionality or not, delete this and switch expanded-view-icons' onClick back to handleThumbNailClick if not
-  const handleIconClick = (url, idx) => {
-    selectPhoto(url);
-    changePhotoIndex(idx);
-  }
-
-  useEffect(() => {
-    // console.log(expandedGalleryView)
-  }, [expandedGalleryView])
-
 
   return (
     <div className='image-gallery-outer'>
@@ -153,7 +134,9 @@ export default function ImageGallery({ selectPhoto, photos }) {
         <div
           className='image-gallery'
           style={mainImageCSS(photos[selectedPhotoIndex].url)}
-          >
+          onClick={() => expandedGalleryView ? null : toggleGalleryView(true)}
+        >
+          {renderThumbnails()}
           {/* EXPANDED VIEW */}
           <Modal id='expanded-gallery-modal' isOpen={expandedGalleryView} style={modalStyle} ariaHideApp={false} >
             <ExpandedView
@@ -161,21 +144,16 @@ export default function ImageGallery({ selectPhoto, photos }) {
               photos={photos}
               selectedPhotoIndex={selectedPhotoIndex}
               url={photos[selectedPhotoIndex].url}
-              handleIconClick={handleIconClick}
-              back={() => scrollBack}
-              forward={() => scrollForward}
+              handleIconClick={handleThumbnailClick}
+              back={scrollBack}
+              forward={scrollForward}
             >
             </ExpandedView>
           </Modal>
 
-          {renderThumbnails()}
-
           {/* todo: refactor this disgusting css/hardcoding */}
-          <button className='horizontal-arrow' id={selectedPhotoIndex > 0 ? 'left-arrow' : 'left-hidden'} onClick={() => scrollBack()}>&#x2190;</button>
-          <button className='horizontal-arrow' id={selectedPhotoIndex < photos.length - 1 ? 'right-arrow' : 'right-hidden'} onClick={() => scrollForward()}>&#x2192;</button>
-
-          {/* expanded view is supposed to open on img click, but for now just use this button */}
-          <button onClick={() => toggleGalleryView(!expandedGalleryView)} style={{width: 200, height: 20}}>open the EXPANDED VIEW</button>
+          <button className='horizontal-arrow' id={selectedPhotoIndex > 0 ? 'left-arrow' : 'left-hidden'} onClick={(event) => {scrollBack(event)}}>&#x2190;</button>
+          <button className='horizontal-arrow' id={selectedPhotoIndex < photos.length - 1 ? 'right-arrow' : 'right-hidden'} onClick={(event) => {scrollForward(event)}}>&#x2192;</button>
         </div>
         : null}
     </div>

--- a/react-client/src/components/product-overview/ImageGallery.jsx
+++ b/react-client/src/components/product-overview/ImageGallery.jsx
@@ -75,7 +75,6 @@ export default function ImageGallery({ selectPhoto, photos }) {
               onClick={(event) => {
                 handleThumbnailClick(event, photo.url, i)
               }}
-              // onClick={() => handleThumbnailClick(photo.url, i)}
               id={i === selectedPhotoIndex ? 'selected' : null}
             />
           })}
@@ -127,7 +126,6 @@ export default function ImageGallery({ selectPhoto, photos }) {
     }
   }
 
-
   return (
     <div className='image-gallery-outer'>
       {photos.length ?
@@ -137,6 +135,7 @@ export default function ImageGallery({ selectPhoto, photos }) {
           onClick={() => expandedGalleryView ? null : toggleGalleryView(true)}
         >
           {renderThumbnails()}
+
           {/* EXPANDED VIEW */}
           <Modal id='expanded-gallery-modal' isOpen={expandedGalleryView} style={modalStyle} ariaHideApp={false} >
             <ExpandedView

--- a/react-client/src/components/product-overview/ProductDescription.jsx
+++ b/react-client/src/components/product-overview/ProductDescription.jsx
@@ -51,7 +51,6 @@ function ProductDescription({ selectedProduct }) {
             <div className='product-slogan'>{selectedProduct.slogan}</div>
             <div className='product-description'>{selectedProduct.description}</div>
           </div>
-          {/* todo - mock shows a horizontal line seperating the description/slogan and feature list */}
           {features.length ?
             <ul className='feature-list'>
               {renderFeatures()}


### PR DESCRIPTION
-using package prismaZoom for expanded gallery zoom in functionality. can zoom in 2.5x, pan around, zoom out, nav with arrows or icons, then close with X button, but that's not exactly the user experience that the doc calls for so it still needs work (plus css)
-added cursor changes depending on the state the image gallery is in
-added event.stopPropagation to all my gallery navigation functions so that main gallery img's onClick wouldn't fire all the time
-minor refactors and some organization of existing components and css
-added a horizontal line dividing the prodct description from features as shown in mock
