### PR TITLE
expanded image gallery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10252,29 +10252,12 @@
         }
       }
     },
-    "react-image-magnifiers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-image-magnifiers/-/react-image-magnifiers-1.4.0.tgz",
-      "integrity": "sha512-ZszHusdsYteccKGysHXUOgLRGtHqfRYuG1koHh3VAvuhrzF4BEs1Ot5tSe1WA2v+EsjAEfYcrRyi/Is4QDD61A==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "react-input-position": "^1.3.1"
-      }
-    },
     "react-input-autosize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
       "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
       "requires": {
         "prop-types": "^15.5.8"
-      }
-    },
-    "react-input-position": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/react-input-position/-/react-input-position-1.3.2.tgz",
-      "integrity": "sha512-0RsvWZ+pBpFki1N4CF7dWWKgQpejQuf9qjrBVdXRE315kk6HBEVk1f8rsod6Rpo88vxPwj5FcBnn7ZlTNq+JRA==",
-      "requires": {
-        "prop-types": "^15.7.2"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-dom": "^17.0.1",
     "react-fontawesome": "^1.7.1",
     "react-highlight-words": "^0.17.0",
-    "react-image-magnifiers": "^1.4.0",
     "react-modal": "^3.12.1",
     "react-select": "^4.1.0"
   }

--- a/react-client/dist/overview.css
+++ b/react-client/dist/overview.css
@@ -140,7 +140,7 @@
 .horizontal-arrow {
   border: none;
   background: none;
-  font-size: 50px;
+  font-size: 40px;
   color: rgb(160,160,160);
   transition-duration: 0.5s;
 }
@@ -185,7 +185,10 @@
   color: red
 }
 
-.expanded-arrow-and-icon-container {
+.expanded-view-message {
+  font-size: 16px;
+  color: rgb(240,240,240);
+  text-shadow: 1px 1px rgb(24,24,24);
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -194,9 +197,29 @@
   top: 5%;
   width: 100%;
   z-index: 10;
+  opacity: 0;
+  animation-name: fade_out;
+  animation-duration: 3s;
+}
+
+.expanded-arrow-and-icon-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 6%;
+  width: 100%;
+  z-index: 10;
   opacity: 1;
   animation-name: fade_in;
-  animation-duration: 1.5s;
+  animation-duration: 0.5s;
+}
+
+.expanded-arrow-and-icon-container-fadeout {
+  opacity: 0;
+  animation-name: fade_out;
+  animation-duration: 0.5s;
 }
 
 .expanded-view-icons-row {
@@ -222,22 +245,6 @@
   background: rgb(255, 0, 140);
 }
 
-.expanded-view-message {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  position: fixed;
-  color: rgb(240,240,240);
-  font-size: 16px;
-  text-shadow: 1px 1px rgb(24,24,24);
-  top: 5%;
-  width: 100%;
-  z-index: 10;
-  opacity: 0;
-  transition-duration: 0.5s;
-  animation-name: fade_out;
-  animation-duration: 3s;
-}
 
 .expanded-view-image {
   object-fit: scale-down;
@@ -250,6 +257,14 @@
   max-height: 95%;
   overflow-x: hidden;
   overflow-y: hidden;
+}
+
+.expanded-view-image#not-zoomed:hover {
+  cursor: zoom-in;
+}
+
+.expanded-view-image#zoomed:hover {
+  cursor: all-scroll; /* should be - */
 }
 
 .right-side {
@@ -484,3 +499,33 @@
   font-size: 24px;
   margin-bottom: 1rem;
 }
+
+/* ZoomedImage.jsx */
+
+figure {
+  width: 100vw;
+  background-repeat: no-repeat;
+  border: 2px solid rgb(24,24,24);
+  border-radius: 0.25rem;
+}
+
+figure:hover {
+  cursor: all-scroll /* should be minus */
+}
+
+figure:hover img {
+  opacity: 0;
+}
+
+#zoomed-image {
+  background-repeat: no-repeat;
+  object-fit: contain;
+  object-position: 50% 50%;
+  display: block;
+  margin: auto;
+  width: 100%;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: hidden;
+}
+

--- a/react-client/src/components/App.jsx
+++ b/react-client/src/components/App.jsx
@@ -87,20 +87,20 @@ export default class App extends React.Component {
         <Overview
           product={this.state.selectedProduct}
           avgRating={this.state.avgRating} />
-        <RelatedItemsList
+        {/* <RelatedItemsList
           selectProduct={this.selectProduct}
           avgRating={this.state.avgRating}
           currentProduct={this.state.selectedProduct} />
         <YourOutfitList
           avgRating={this.state.avgRating}
-          currentProduct={this.state.selectedProduct} />
+          currentProduct={this.state.selectedProduct} /> */}
         {/* <QA
           currentProduct={this.state.selectedProduct} />  */}
-        <Reviews
+        {/* <Reviews
           avgRating={this.state.avgRating}
           metadata={this.state.metadata}
           getRatings={this.getRatings}
-          currentProduct={this.state.selectedProduct.id} />
+          currentProduct={this.state.selectedProduct.id} /> */}
       </div>
     )
   }

--- a/react-client/src/components/product-overview/ExpandedView_new.jsx
+++ b/react-client/src/components/product-overview/ExpandedView_new.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Magnifier, MOUSE_ACTIVATION, TOUCH_ACTIVATION } from "react-image-magnifiers";
+import ZoomedImage from './ZoomedImage.jsx';
+// UNINSTALL REACT IMAGE MAGNIFIERS
 
 export default function ExpandedView({ close, handleIconClick, url, photos, back, forward, selectedPhotoIndex }) {
 
@@ -19,21 +20,18 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
     </div>
   }
 
-  useEffect(() => {
-    let box = document.querySelector('.expanded-view-image');
-    if (box !== null) {
-      let width = box.clientWidth;
-      let height = box.clientHeight;
-      console.log(`img number ${selectedPhotoIndex} dimensions: ${width} x ${height}`)
-    }
-  }, [url])
+  const zoom = () => {
+    toggleZoom(!isZoomed)
+  }
 
   return (
     <div className='expanded-gallery-modal-inner'>
       <button onClick={() => close()} id='modal-x-button'>&#x2715;</button>
       {isZoomed ?
-        <div className='expanded-view-message'>pan around by dragging the cursor; click again to zoom out</div>
-        :
+        <ZoomedImage url={url} zoom={zoom} />
+        : <img className='expanded-view-image' onClick={() => zoom()} src={url} />
+      }
+      <div className={isZoomed ? 'expanded-arrow-and-icon-container-fadeout' : 'expanded-arrow-and-icon-container'} >
         <div className='expanded-arrow-and-icon-container'>
           <button
             id={selectedPhotoIndex > 0 ? null : 'hidden'}
@@ -41,7 +39,7 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
             style={{ marginTop: '-0.5rem' }}
             onClick={(e) => { back(e) }}
           >&#x2190;
-            </button>
+          </button>
           {renderExpandedViewIcons()}
           <button
             id={selectedPhotoIndex < photos.length - 1 ? null : 'hidden'}
@@ -49,20 +47,10 @@ export default function ExpandedView({ close, handleIconClick, url, photos, back
             style={{ marginTop: '-0.5rem' }}
             onClick={(e) => { forward(e) }}
           >&#x2192;
-            </button>
+          </button>
         </div>
-      }
-      <Magnifier
-        className='expanded-view-image'
-        cursorStyle='crosshair'
-        imageSrc={url}
-        imageAlt='HEIR FORCE ONES'
-        onZoomStart={() => toggleZoom(true)}
-        onZoomEnd={() => toggleZoom(false)}
-        mouseActivation={MOUSE_ACTIVATION.CLICK}
-        touchActivation={TOUCH_ACTIVATION.TAP}
-        dragToMove={false}
-      />
-    </div >
+      </div>
+    </div>
+
   )
 }

--- a/react-client/src/components/product-overview/ImageGallery.jsx
+++ b/react-client/src/components/product-overview/ImageGallery.jsx
@@ -1,6 +1,12 @@
 import React, { useState, useEffect } from 'react';
-// import ExpandedView from './ExpandedView_old.jsx'; // keeping a copy of old one with prismazoom for now, will delete one of these and uninstall the unneeded package by the time we deploy
-import ExpandedView from './ExpandedView.jsx';
+import ExpandedView from './ExpandedView_old.jsx';
+
+// ^ the old one has less smooth controls (double click + click and drag instead of single click + follow mouse) but actually works without bugs.
+
+// going to spend a few hours trying to debug the the newer version but will just keep the _old one when we deploy if i have to
+
+// import ExpandedView from './ExpandedView_new.jsx';
+
 import Modal from 'react-modal';
 
 const modalStyle = {

--- a/react-client/src/components/product-overview/ZoomedImage.jsx
+++ b/react-client/src/components/product-overview/ZoomedImage.jsx
@@ -1,0 +1,26 @@
+import React, {useState, useEffect} from 'react';
+
+export default function ZoomedImage({url, zoom}) {
+
+  const [backgroundImage, setBackgroundImage] = useState('');
+  const [backgroundPosition, changePosition] = useState('0% 0%')
+
+  useEffect(() => {
+    setBackgroundImage(`url(${url})`)
+  }, [url])
+
+  const handleMouseMove = e => {
+    const { left, top, width, height } = e.target.getBoundingClientRect()
+    const x = (e.pageX - left) / width * 250
+    const y = (e.pageY - top) / height * 250
+    changePosition(`${x}% ${y}%`)
+  }
+
+  return (
+    <figure onMouseMove={(e) => handleMouseMove(e)} style={{backgroundImage, backgroundPosition}} onClick={() => zoom()}>
+      <img id='zoomed-image' src={url} />
+    </figure>
+  )
+
+}
+


### PR DESCRIPTION
- working on implementing a new version of the expanded view that has smoother controls but it still has some bugs on the vertical images and with overflowing out of its container
- got the old version that requires double clicks stable in case the new one doesnt work out. seems to work for all images sizes consistently. old/stable version is what is currently rendered onto the overview widget